### PR TITLE
Better API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ And many, many more, all of which I will not find anymore...
 - [ ] Add interpolation with perspective correction
 - [ ] Fix rasterization rules (see the gaps between triangles in `03_spinning_textured_cube` example)
 - [ ] Implement other primitives (lines, points, lines/triangles strip/adjacency etc.)
+- [ ] Implement interpolation for types other than `double` (shouldn't it just be `double` and `float`?)
 - [ ] Add multisampling
 - [ ] Advanced texture techniques:
     - [ ] (Bi)linear filtering
@@ -69,9 +70,11 @@ And many, many more, all of which I will not find anymore...
 - [ ] Use a profiler to find bottlenecks in frequently-used functions
 - [ ] Draw primitives in parallel (OpenMP)
 
-### Portability
+### Portability/API design
 - [x] Give the user an opportunity to avoid including `vec.h` and `mat.h` (one more header guard?)
 - [x] Use `const` in function declarations where needed
+- [ ] Reorder arguments in drawcalls
+- [ ] Hide the API structure definitions to avoid users modifying structure members themselves
 
 ## What I learned
 This is a section specially for my portfolio, so feel free to skip it. Well, I learned:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ And many, many more, all of which I will not find anymore...
 ## TODO
 ### Documentation/examples
 - [x] Add comments to the examples
-- [ ] Prettify the API (think about convenience macros/functions)
+- [x] Prettify the API (think about convenience macros/functions)
 - [ ] Write the documentation about the main pipeline and individual functions
 
 ### Features
@@ -73,8 +73,8 @@ And many, many more, all of which I will not find anymore...
 ### Portability/API design
 - [x] Give the user an opportunity to avoid including `vec.h` and `mat.h` (one more header guard?)
 - [x] Use `const` in function declarations where needed
-- [ ] Reorder arguments in drawcalls
-- [ ] Hide the API structure definitions to avoid users modifying structure members themselves
+- [x] Reorder arguments in drawcalls
+- [ ] Add realloc and etc. functions for buffer objects (see OpenGL for reference)
 
 ## What I learned
 This is a section specially for my portfolio, so feel free to skip it. Well, I learned:

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ And many, many more, all of which I will not find anymore...
     - [ ] Transparent textures?
 
 ### Optimization
+- [ ] Are `vec` and `mat` functions inlined by the compiler? Should they be? Are `mat` or `vec` ever passed by-value?
 - [ ] Use a profiler to find bottlenecks in frequently-used functions
 - [ ] Draw primitives in parallel (OpenMP)
 
 ### Portability
 - [x] Give the user an opportunity to avoid including `vec.h` and `mat.h` (one more header guard?)
-- [ ] Use `const` in function declarations where needed
+- [x] Use `const` in function declarations where needed
 
 ## What I learned
 This is a section specially for my portfolio, so feel free to skip it. Well, I learned:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ And many, many more, all of which I will not find anymore...
 - [ ] Draw primitives in parallel (OpenMP)
 
 ### Portability
-- [ ] Give the user an opportunity to avoid including `vec.h` and `mat.h` (one more header guard?)
+- [x] Give the user an opportunity to avoid including `vec.h` and `mat.h` (one more header guard?)
+- [ ] Use `const` in function declarations where needed
 
 ## What I learned
 This is a section specially for my portfolio, so feel free to skip it. Well, I learned:

--- a/examples/01_colored_triangle/main.c
+++ b/examples/01_colored_triangle/main.c
@@ -74,7 +74,7 @@ int main()
 
 	// This stores the information about vertex shader's output variables that
 	// is necessary to interpolate them inside the primitive
-	SRPVertexVariable VSOutputVariables[1] = {
+	SRPVertexVariableInformation VSOutputVariables[1] = {
 		{
 			.nItems = 3,
 			.type = TYPE_DOUBLE,

--- a/examples/01_colored_triangle/main.c
+++ b/examples/01_colored_triangle/main.c
@@ -67,25 +67,19 @@ int main()
 	// Creating the vertex buffer object, it is similar to OpenGL's VBO
 	SRPVertexBuffer* vb = srpNewVertexBuffer(sizeof(Vertex), sizeof(data), data);
 
-	// This stores the information about vertex shader's output variables that
-	// is necessary to interpolate them inside the primitive
-	SRPVertexVariableInformation VSOutputVariables[1] = {
-		{
-			.nItems = 3,
-			.type = TYPE_DOUBLE,
-			.offsetBytes = 0
-		}
-	};
-
 	// Shader program is not actually a program, but named like this to
 	// be similar to OpenGL
 	SRPShaderProgram shaderProgram = {
 		.uniform = NULL,
 		.vs = {
 			.shader = vertexShader,
-			.nBytesPerOutputVariables = sizeof(VSOutput),
+			// This stores the information about vertex shader's output variables
+			// that is necessary to interpolate them inside the primitive
 			.nOutputVariables = 1,
-			.outputVariables = VSOutputVariables
+			.outputVariables = (SRPVertexVariableInformation[]) {
+				{.nItems = 3, .type = TYPE_DOUBLE}
+			},
+			.nBytesPerOutputVariables = sizeof(VSOutput)
 		},
 		.fs = {
 			.shader = fragmentShader
@@ -152,10 +146,7 @@ void vertexShader(SRPvsInput* in, SRPvsOutput* out)
 	*outPosition = (vec4d) {
 		inPosition->x, inPosition->y, inPosition->z, 1.0
 	};
-
-	pOutVars->color.x = pVertex->color.x;
-	pOutVars->color.y = pVertex->color.y;
-	pOutVars->color.z = pVertex->color.z;
+	pOutVars->color = pVertex->color;
 
 	// What we have done is just copied the inputs to the outputs
 	// The simplest vertex shader possible!

--- a/examples/01_colored_triangle/main.c
+++ b/examples/01_colored_triangle/main.c
@@ -63,14 +63,9 @@ int main()
 			.color = {0., 1., 0.}
 		}
 	};
-	uint8_t indices[3] = {
-		0, 1, 2
-	};
 
-	// Creating the vertex and index buffer objects. These are similar to
-	// OpenGL's VBO and EBO
+	// Creating the vertex buffer object, it is similar to OpenGL's VBO
 	SRPVertexBuffer* vb = srpNewVertexBuffer(sizeof(Vertex), sizeof(data), data);
-	SRPIndexBuffer* ib = srpNewIndexBuffer(TYPE_UINT8, sizeof(indices), indices);
 
 	// This stores the information about vertex shader's output variables that
 	// is necessary to interpolate them inside the primitive
@@ -90,7 +85,7 @@ int main()
 			.shader = vertexShader,
 			.nBytesPerOutputVariables = sizeof(VSOutput),
 			.nOutputVariables = 1,
-			.outputVariables = VSOutputVariables,
+			.outputVariables = VSOutputVariables
 		},
 		.fs = {
 			.shader = fragmentShader
@@ -110,7 +105,7 @@ int main()
 
 		// Clear the framebuffer and draw the index buffer as triangles
 		framebufferClear(fb);
-		srpDrawIndexBuffer(fb, ib, vb, PRIMITIVE_TRIANGLES, 0, 3, &shaderProgram);
+		srpDrawVertexBuffer(fb, vb, PRIMITIVE_TRIANGLES, 0, 3, &shaderProgram);
 
 		windowPollEvents(window);
 		windowPresent(window, fb);
@@ -127,7 +122,6 @@ int main()
 
 	// Destroy objects
 	srpFreeVertexBuffer(vb);
-	srpFreeIndexBuffer(ib);
 	srpFreeFramebuffer(fb);
 	freeWindow(window);
 

--- a/examples/02_spinning_triangle/main.c
+++ b/examples/02_spinning_triangle/main.c
@@ -58,7 +58,7 @@ int main()
 		0, 1, 2
 	};
 
-	SRPVertexVariable VSOutputVariables[1] = {
+	SRPVertexVariableInformation VSOutputVariables[1] = {
 		{
 			.nItems = 3,
 			.type = TYPE_DOUBLE,

--- a/examples/02_spinning_triangle/main.c
+++ b/examples/02_spinning_triangle/main.c
@@ -55,14 +55,6 @@ int main()
 		}
 	};
 
-	SRPVertexVariableInformation VSOutputVariables[1] = {
-		{
-			.nItems = 3,
-			.type = TYPE_DOUBLE,
-			.offsetBytes = 0
-		}
-	};
-
 	SRPVertexBuffer* vb = srpNewVertexBuffer(sizeof(Vertex), sizeof(data), data);
 
 	// Uniform requires a cast to an opaque `SRPUniform` type to avoid
@@ -72,9 +64,11 @@ int main()
 		.uniform = (SRPUniform*) &uniform,
 		.vs = {
 			.shader = vertexShader,
-			.nBytesPerOutputVariables = sizeof(VSOutput),
 			.nOutputVariables = 1,
-			.outputVariables = VSOutputVariables,
+			.outputVariables = (SRPVertexVariableInformation[]) {
+				{.nItems = 3, .type = TYPE_DOUBLE}
+			},
+			.nBytesPerOutputVariables = sizeof(VSOutput)
 		},
 		.fs = {
 			.shader = fragmentShader

--- a/examples/02_spinning_triangle/main.c
+++ b/examples/02_spinning_triangle/main.c
@@ -54,9 +54,6 @@ int main()
 			.color = {0., 1., 0.}
 		}
 	};
-	uint8_t indices[3] = {
-		0, 1, 2
-	};
 
 	SRPVertexVariableInformation VSOutputVariables[1] = {
 		{
@@ -67,7 +64,6 @@ int main()
 	};
 
 	SRPVertexBuffer* vb = srpNewVertexBuffer(sizeof(Vertex), sizeof(data), data);
-	SRPIndexBuffer* ib = srpNewIndexBuffer(TYPE_UINT8, sizeof(indices), indices);
 
 	// Uniform requires a cast to an opaque `SRPUniform` type to avoid
 	// a compiler warning
@@ -96,7 +92,7 @@ int main()
 		// top of this file (`SRP_INCLUDE_...`)
 		uniform.rotation = mat4dConstructRotate(0, 0, uniform.frameCount / 1000.);
 		framebufferClear(fb);
-		srpDrawIndexBuffer(fb, ib, vb, PRIMITIVE_TRIANGLES, 0, 3, &shaderProgram);
+		srpDrawVertexBuffer(fb, vb, PRIMITIVE_TRIANGLES, 0, 3, &shaderProgram);
 
 		windowPollEvents(window);
 		windowPresent(window, fb);
@@ -112,7 +108,6 @@ int main()
 	}
 
 	srpFreeVertexBuffer(vb);
-	srpFreeIndexBuffer(ib);
 	srpFreeFramebuffer(fb);
 	freeWindow(window);
 

--- a/examples/03_spinning_textured_cube/main.c
+++ b/examples/03_spinning_textured_cube/main.c
@@ -169,7 +169,6 @@ void messageCallback(
 
 void vertexShader(SRPvsInput* in, SRPvsOutput* out)
 {
-
 	Vertex* pVertex = (Vertex*) in->pVertex;
 	Uniform* pUniform = (Uniform*) in->uniform;
 	VSOutput* pOutVars = (VSOutput*) out->pOutputVariables;
@@ -194,10 +193,6 @@ void fragmentShader(SRPfsInput* in, SRPfsOutput* out)
 	vec4d* outColor = (vec4d*) out->color;
 
 	vec2d uv = interpolated->uv;
-	SRPColor color = srpTextureGetFilteredColor(pUniform->texture, uv.x, uv.y);
-	outColor->x = color.r / 255.;
-	outColor->y = color.g / 255.;
-	outColor->z = color.b / 255.;
-	outColor->w = color.a / 255.;
+	srpTextureGetFilteredColor(pUniform->texture, uv.x, uv.y, (double*) outColor);
 }
 

--- a/examples/03_spinning_textured_cube/main.c
+++ b/examples/03_spinning_textured_cube/main.c
@@ -1,3 +1,4 @@
+#include "vertex.h"
 #define SRP_INCLUDE_VEC
 #define SRP_INCLUDE_MAT
 
@@ -86,14 +87,6 @@ int main()
 	SRPVertexBuffer* vb = srpNewVertexBuffer(sizeof(Vertex), sizeof(data), data);
 	SRPIndexBuffer* ib = srpNewIndexBuffer(TYPE_UINT8, sizeof(indices), indices);
 
-	SRPVertexVariableInformation VSOutputVariables[1] = {
-		{
-			.nItems = 2,
-			.type = TYPE_DOUBLE,
-			.offsetBytes = 0
-		}
-	};
-
 	Uniform uniform = {
 		.model = mat4dConstructIdentity(),
 		.view = mat4dConstructView(
@@ -114,9 +107,11 @@ int main()
 		.uniform = (SRPUniform*) &uniform,
 		.vs = {
 			.shader = vertexShader,
-			.nBytesPerOutputVariables = sizeof(VSOutput),
 			.nOutputVariables = 1,
-			.outputVariables = VSOutputVariables,
+			.outputVariables = (SRPVertexVariableInformation[])	{
+				{.nItems = 2, .type = TYPE_DOUBLE}
+			},
+			.nBytesPerOutputVariables = sizeof(VSOutput)
 		},
 		.fs = {
 			.shader = fragmentShader

--- a/examples/03_spinning_textured_cube/main.c
+++ b/examples/03_spinning_textured_cube/main.c
@@ -82,10 +82,11 @@ int main()
 		20, 23, 22,  20, 22, 21
 	};
 
+	// Create vertex and index buffers, these are similar to VBO and EBO
 	SRPVertexBuffer* vb = srpNewVertexBuffer(sizeof(Vertex), sizeof(data), data);
 	SRPIndexBuffer* ib = srpNewIndexBuffer(TYPE_UINT8, sizeof(indices), indices);
 
-	SRPVertexVariable VSOutputVariables[1] = {
+	SRPVertexVariableInformation VSOutputVariables[1] = {
 		{
 			.nItems = 2,
 			.type = TYPE_DOUBLE,

--- a/examples/utility/window.c
+++ b/examples/utility/window.c
@@ -46,7 +46,7 @@ void windowPollEvents(Window* this)
 	}
 }
 
-void windowPresent(Window* this, SRPFramebuffer* fb)
+void windowPresent(const Window* this, const SRPFramebuffer* fb)
 {
 	SDL_UpdateTexture(this->texture, NULL, fb->color, fb->width * sizeof(SRPColor));
 	SDL_RenderCopy(this->renderer, this->texture, NULL, NULL);

--- a/examples/utility/window.h
+++ b/examples/utility/window.h
@@ -17,5 +17,5 @@ Window* newWindow(size_t width, size_t height, char* title, bool fullscreen);
 void freeWindow(Window* this);
 
 void windowPollEvents(Window* this);
-void windowPresent(Window* this, SRPFramebuffer* fb);
+void windowPresent(const Window* this, const SRPFramebuffer* fb);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
 	vec.c
 	mat.c
 	alloc.c
+	message_callback.c
 )
 
 add_library(srp STATIC ${SOURCES})

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -74,7 +74,7 @@ static uint64_t indexIndexBuffer(SRPIndexBuffer* this, size_t index)
 			ret = (uint64_t) (*(uint64_t*) pIndex);
 			break;
 		default:
-			messageCallback(
+			srpMessageCallbackHelper(
 				MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 				"Unexpected type (%i)", this->indicesType
 			);
@@ -91,7 +91,7 @@ void srpDrawIndexBuffer(
 {
 	if (primitive != PRIMITIVE_TRIANGLES)
 	{
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Only triangles are implemented"
 		);
@@ -101,7 +101,7 @@ void srpDrawIndexBuffer(
 	size_t endIbIndex = startIbIndex + count;
 	if (endIbIndex > this->nIndices)
 	{
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Attempt to OOB access index buffer"
 		);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -10,11 +10,12 @@
 #include "defines.h"
 
 static void drawBuffer(
-	SRPFramebuffer* fb, SRPIndexBuffer* this, SRPVertexBuffer* vb,
-	SRPPrimitive primitive, size_t startIndex, size_t count, SRPShaderProgram* sp
+	const SRPFramebuffer* fb, const SRPIndexBuffer* this,
+	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIndex,
+	size_t count, const SRPShaderProgram* sp
 );
-static uint64_t indexIndexBuffer(SRPIndexBuffer* this, size_t index);
-static SRPVertex* indexVertexBuffer(SRPVertexBuffer* this, size_t index);
+static uint64_t indexIndexBuffer(const SRPIndexBuffer* this, size_t index);
+static SRPVertex* indexVertexBuffer(const SRPVertexBuffer* this, size_t index);
 
 // An internal function to draw either index or vertex buffer
 // If `ib == NULL`, draws the vertex buffer, else draws index buffer
@@ -22,8 +23,9 @@ static SRPVertex* indexVertexBuffer(SRPVertexBuffer* this, size_t index);
 // Created because vertex and index buffer drawing are very similar,
 // with an intent to avoid code duplication
 static void drawBuffer(
-	SRPFramebuffer* fb, SRPIndexBuffer* ib, SRPVertexBuffer* vb,
-	SRPPrimitive primitive, size_t startIndex, size_t count, SRPShaderProgram* sp
+	const SRPFramebuffer* fb, const SRPIndexBuffer* ib,
+	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIndex,
+	size_t count, const SRPShaderProgram* sp
 )
 {
 	const bool isDrawingIndexBuffer = (ib != NULL);
@@ -98,7 +100,9 @@ static void drawBuffer(
 	SRP_FREE(triangleOutputVertexVariables);
 }
 
-SRPVertexBuffer* srpNewVertexBuffer(size_t nBytesPerVertex, size_t nBytesData, void* data)
+SRPVertexBuffer* srpNewVertexBuffer(
+	size_t nBytesPerVertex, size_t nBytesData, const void* data
+)
 {
 	SRPVertexBuffer* this = SRP_MALLOC(sizeof(SRPVertexBuffer));
 
@@ -118,19 +122,21 @@ void srpFreeVertexBuffer(SRPVertexBuffer* this)
 }
 
 void srpDrawVertexBuffer(
-	SRPFramebuffer* fb, SRPVertexBuffer* this, SRPPrimitive primitive,
-	size_t startIndex, size_t count, SRPShaderProgram* sp
+	const SRPFramebuffer* fb, const SRPVertexBuffer* this, SRPPrimitive primitive,
+	size_t startIndex, size_t count, const SRPShaderProgram* sp
 )
 {
 	drawBuffer(fb, NULL, this, primitive, startIndex, count, sp);
 }
 
-static SRPVertex* indexVertexBuffer(SRPVertexBuffer* this, size_t index)
+static SRPVertex* indexVertexBuffer(const SRPVertexBuffer* this, size_t index)
 {
 	return (SRPVertex*) INDEX_VOID_PTR(this->data, index, this->nBytesPerVertex);
 }
 
-SRPIndexBuffer* srpNewIndexBuffer(Type indicesType, size_t nBytesData, void* data)
+SRPIndexBuffer* srpNewIndexBuffer(
+	Type indicesType, size_t nBytesData, const void* data
+)
 {
 	SRPIndexBuffer* this = SRP_MALLOC(sizeof(SRPIndexBuffer));
 
@@ -149,7 +155,7 @@ void srpFreeIndexBuffer(SRPIndexBuffer* this)
 	SRP_FREE(this);
 }
 
-static uint64_t indexIndexBuffer(SRPIndexBuffer* this, size_t index)
+static uint64_t indexIndexBuffer(const SRPIndexBuffer* this, size_t index)
 {
 	void* pIndex = INDEX_VOID_PTR(this->data, index, this->nBytesPerIndex);
 	uint64_t ret;
@@ -179,8 +185,9 @@ static uint64_t indexIndexBuffer(SRPIndexBuffer* this, size_t index)
 
 // @brief Draw an index buffer with specified primitive mode
 void srpDrawIndexBuffer(
-	SRPFramebuffer* fb, SRPIndexBuffer* this, SRPVertexBuffer* vb, SRPPrimitive primitive,
-	size_t startIbIndex, size_t count, SRPShaderProgram* sp
+	const SRPFramebuffer* fb, const SRPIndexBuffer* this,
+	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIbIndex,
+	size_t count, const SRPShaderProgram* sp
 )
 {
 	drawBuffer(fb, this, vb, primitive, startIbIndex, count, sp);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -10,9 +10,8 @@
 #include "defines.h"
 
 static void drawBuffer(
-	const SRPFramebuffer* fb, const SRPIndexBuffer* this,
-	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIndex,
-	size_t count, const SRPShaderProgram* sp
+	const SRPIndexBuffer* ib, const SRPVertexBuffer* vb, const SRPFramebuffer* fb,
+	const SRPShaderProgram* sp, SRPPrimitive primitive, size_t startIndex, size_t count
 );
 static uint64_t indexIndexBuffer(const SRPIndexBuffer* this, size_t index);
 static SRPVertex* indexVertexBuffer(const SRPVertexBuffer* this, size_t index);
@@ -23,9 +22,8 @@ static SRPVertex* indexVertexBuffer(const SRPVertexBuffer* this, size_t index);
 // Created because vertex and index buffer drawing are very similar,
 // with an intent to avoid code duplication
 static void drawBuffer(
-	const SRPFramebuffer* fb, const SRPIndexBuffer* ib,
-	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIndex,
-	size_t count, const SRPShaderProgram* sp
+	const SRPIndexBuffer* ib, const SRPVertexBuffer* vb, const SRPFramebuffer* fb,
+	const SRPShaderProgram* sp, SRPPrimitive primitive, size_t startIndex, size_t count
 )
 {
 	const bool isDrawingIndexBuffer = (ib != NULL);
@@ -122,11 +120,11 @@ void srpFreeVertexBuffer(SRPVertexBuffer* this)
 }
 
 void srpDrawVertexBuffer(
-	const SRPFramebuffer* fb, const SRPVertexBuffer* this, SRPPrimitive primitive,
-	size_t startIndex, size_t count, const SRPShaderProgram* sp
+	const SRPVertexBuffer* this, const SRPFramebuffer* fb, const SRPShaderProgram* sp,
+	SRPPrimitive primitive, size_t startIndex, size_t count
 )
 {
-	drawBuffer(fb, NULL, this, primitive, startIndex, count, sp);
+	drawBuffer(NULL, this, fb, sp, primitive, startIndex, count);
 }
 
 static SRPVertex* indexVertexBuffer(const SRPVertexBuffer* this, size_t index)
@@ -185,11 +183,10 @@ static uint64_t indexIndexBuffer(const SRPIndexBuffer* this, size_t index)
 
 // @brief Draw an index buffer with specified primitive mode
 void srpDrawIndexBuffer(
-	const SRPFramebuffer* fb, const SRPIndexBuffer* this,
-	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIbIndex,
-	size_t count, const SRPShaderProgram* sp
+	const SRPIndexBuffer* this, const SRPVertexBuffer* vb, const SRPFramebuffer* fb,
+	const SRPShaderProgram* sp, SRPPrimitive primitive, size_t startIndex, size_t count
 )
 {
-	drawBuffer(fb, this, vb, primitive, startIbIndex, count, sp);
+	drawBuffer(this, vb, fb, sp, primitive, startIndex, count);
 }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -108,7 +108,7 @@ void srpDrawIndexBuffer(
 		return;
 	}
 
-	VSOutputVariable* triangleVSOutputVariables = \
+	SRPVertexVariable* triangleVSOutputVariables = \
 		SRP_MALLOC(sp->vs.nBytesPerOutputVariables * 3);
 	size_t primitiveID = 0;
 
@@ -120,7 +120,7 @@ void srpDrawIndexBuffer(
 		{
 			uint64_t vertexIndex = indexIndexBuffer(this, i + j);
 			SRPVertex* pInVertex = indexVertexBuffer(vb, vertexIndex);
-			VSOutputVariable* pVSOutputVariables = (VSOutputVariable*) \
+			SRPVertexVariable* pVSOutputVariables = (SRPVertexVariable*) \
 				INDEX_VOID_PTR(triangleVSOutputVariables, j, sp->vs.nBytesPerOutputVariables);
 
 			vsIn[j] = (SRPvsInput) {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -25,17 +25,22 @@ typedef struct SRPIndexBuffer
 } SRPIndexBuffer;
 
 // TODO: drawVertexBuffer
-SRPVertexBuffer* srpNewVertexBuffer(size_t nBytesPerVertex, size_t nBytesData, void* data);
+SRPVertexBuffer* srpNewVertexBuffer(
+	size_t nBytesPerVertex, size_t nBytesData, const void* data
+);
 void srpFreeVertexBuffer(SRPVertexBuffer* this);
 void srpDrawVertexBuffer(
-	SRPFramebuffer* fb, SRPVertexBuffer* this, SRPPrimitive primitive,
-	size_t startIndex, size_t count, SRPShaderProgram* sp
+	const SRPFramebuffer* fb, const SRPVertexBuffer* this, SRPPrimitive primitive,
+	size_t startIndex, size_t count, const SRPShaderProgram* sp
 );
 
-SRPIndexBuffer* srpNewIndexBuffer(Type indicesType, size_t nBytesData, void* data);
+SRPIndexBuffer* srpNewIndexBuffer(
+	Type indicesType, size_t nBytesData, const void* data
+);
 void srpFreeIndexBuffer(SRPIndexBuffer* this);
 void srpDrawIndexBuffer(
-	SRPFramebuffer* fb, SRPIndexBuffer* this, SRPVertexBuffer* vb,
-	SRPPrimitive primitive, size_t startIndex, size_t count, SRPShaderProgram* sp
+	const SRPFramebuffer* fb, const SRPIndexBuffer* this,
+	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIndex,
+	size_t count, const SRPShaderProgram* sp
 );
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -27,6 +27,10 @@ typedef struct SRPIndexBuffer
 // TODO: drawVertexBuffer
 SRPVertexBuffer* srpNewVertexBuffer(size_t nBytesPerVertex, size_t nBytesData, void* data);
 void srpFreeVertexBuffer(SRPVertexBuffer* this);
+void srpDrawVertexBuffer(
+	SRPFramebuffer* fb, SRPVertexBuffer* this, SRPPrimitive primitive,
+	size_t startIndex, size_t count, SRPShaderProgram* sp
+);
 
 SRPIndexBuffer* srpNewIndexBuffer(Type indicesType, size_t nBytesData, void* data);
 void srpFreeIndexBuffer(SRPIndexBuffer* this);

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -24,19 +24,16 @@ typedef struct SRPIndexBuffer
 	void* data;
 } SRPIndexBuffer;
 
-// TODO: drawVertexBuffer
-SRPVertexBuffer* srpNewVertexBuffer(
-	size_t nBytesPerVertex, size_t nBytesData, const void* data
-);
+SRPVertexBuffer* srpNewVertexBuffer
+	(size_t nBytesPerVertex, size_t nBytesData, const void* data);
 void srpFreeVertexBuffer(SRPVertexBuffer* this);
 void srpDrawVertexBuffer(
 	const SRPFramebuffer* fb, const SRPVertexBuffer* this, SRPPrimitive primitive,
 	size_t startIndex, size_t count, const SRPShaderProgram* sp
 );
 
-SRPIndexBuffer* srpNewIndexBuffer(
-	Type indicesType, size_t nBytesData, const void* data
-);
+SRPIndexBuffer* srpNewIndexBuffer
+	(Type indicesType, size_t nBytesData, const void* data);
 void srpFreeIndexBuffer(SRPIndexBuffer* this);
 void srpDrawIndexBuffer(
 	const SRPFramebuffer* fb, const SRPIndexBuffer* this,

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -28,16 +28,15 @@ SRPVertexBuffer* srpNewVertexBuffer
 	(size_t nBytesPerVertex, size_t nBytesData, const void* data);
 void srpFreeVertexBuffer(SRPVertexBuffer* this);
 void srpDrawVertexBuffer(
-	const SRPFramebuffer* fb, const SRPVertexBuffer* this, SRPPrimitive primitive,
-	size_t startIndex, size_t count, const SRPShaderProgram* sp
+	const SRPVertexBuffer* this, const SRPFramebuffer* fb, const SRPShaderProgram* sp,
+	SRPPrimitive primitive, size_t startIndex, size_t count
 );
 
 SRPIndexBuffer* srpNewIndexBuffer
 	(Type indicesType, size_t nBytesData, const void* data);
 void srpFreeIndexBuffer(SRPIndexBuffer* this);
 void srpDrawIndexBuffer(
-	const SRPFramebuffer* fb, const SRPIndexBuffer* this,
-	const SRPVertexBuffer* vb, SRPPrimitive primitive, size_t startIndex,
-	size_t count, const SRPShaderProgram* sp
+	const SRPIndexBuffer* this, const SRPVertexBuffer* vb, const SRPFramebuffer* fb,
+	const SRPShaderProgram* sp, SRPPrimitive primitive, size_t startIndex, size_t count
 );
 

--- a/src/context.c
+++ b/src/context.c
@@ -9,7 +9,7 @@ void srpNewContext(SRPContext* context)
 	context->messageCallbackUserParameter = NULL;
 }
 
-void srpContextSetP(SRPContextParameter contextParameter, void* data)
+void srpContextSetP(SRPContextParameter contextParameter, const void* data)
 {
 	switch (contextParameter)
 	{
@@ -17,7 +17,8 @@ void srpContextSetP(SRPContextParameter contextParameter, void* data)
 		srpContext.messageCallback = data;
 		return;
 	case CTX_PARAM_MESSAGE_CALLBACK_USER_PARAMETER:
-		srpContext.messageCallbackUserParameter = data;
+		// TODO: is this cast OK?
+		srpContext.messageCallbackUserParameter = (void*) data;
 		return;
 	default:
 		srpMessageCallbackHelper(

--- a/src/context.c
+++ b/src/context.c
@@ -20,7 +20,7 @@ void srpContextSetP(SRPContextParameter contextParameter, void* data)
 		srpContext.messageCallbackUserParameter = data;
 		return;
 	default:
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Unknown type (%i)", contextParameter
 		);

--- a/src/context.h
+++ b/src/context.h
@@ -16,7 +16,7 @@ typedef enum SRPContextParameter
 } SRPContextParameter;
 
 void srpNewContext(SRPContext* context);
-void srpContextSetP(SRPContextParameter contextParameter, void* data);
+void srpContextSetP(SRPContextParameter contextParameter, const void* data);
 
 extern SRPContext srpContext;
 

--- a/src/framebuffer.c
+++ b/src/framebuffer.c
@@ -6,6 +6,11 @@
 #include "message_callback.h"
 #include "defines.h"
 
+static uint32_t* framebufferGetPixelPointer
+	(const SRPFramebuffer* this, size_t x, size_t y);
+static double* framebufferGetDepthPointer
+	(const SRPFramebuffer* this, size_t x, size_t y);
+
 SRPFramebuffer* srpNewFramebuffer(size_t width, size_t height)
 {
 	SRPFramebuffer* this = SRP_MALLOC(sizeof(SRPFramebuffer));
@@ -27,7 +32,8 @@ void srpFreeFramebuffer(SRPFramebuffer* this)
 }
 
 void framebufferDrawPixel(
-	SRPFramebuffer* this, size_t x, size_t y, double depth, uint32_t color
+	const SRPFramebuffer* this, size_t x, size_t y, double depth,
+	uint32_t color
 )
 {
 	if (1 < depth || depth < -1)
@@ -44,14 +50,16 @@ void framebufferDrawPixel(
 	*pDepth = depth;
 }
 
-void framebufferNDCToScreenSpace(SRPFramebuffer* this, double* NDC, double* SS)
+void framebufferNDCToScreenSpace(
+	const SRPFramebuffer* this, const double* NDC, double* SS
+)
 {
 	SS[0] =  (((double) this->width  - 1) / 2) * (NDC[0] + 1);
 	SS[1] = -(((double) this->height - 1) / 2) * (NDC[1] - 1),
 	SS[2] = NDC[2];
 }
 
-void framebufferClear(SRPFramebuffer *this)
+void framebufferClear(const SRPFramebuffer* this)
 {
 	for (size_t y = 0; y < this->height; y++)
 	{
@@ -63,12 +71,12 @@ void framebufferClear(SRPFramebuffer *this)
 	}
 }
 
-uint32_t* framebufferGetPixelPointer(SRPFramebuffer* this, size_t x, size_t y)
+uint32_t* framebufferGetPixelPointer(const SRPFramebuffer* this, size_t x, size_t y)
 {
 	return this->color + (y * this->width + x);
 }
 
-double* framebufferGetDepthPointer(SRPFramebuffer* this, size_t x, size_t y)
+double* framebufferGetDepthPointer(const SRPFramebuffer* this, size_t x, size_t y)
 {
 	return this->depth + (y * this->width + x);
 }

--- a/src/framebuffer.c
+++ b/src/framebuffer.c
@@ -31,7 +31,7 @@ void framebufferDrawPixel(
 )
 {
 	if (1 < depth || depth < -1)
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Depth value is not inside [-1, 1] interval; depth=%lf", depth
 		);

--- a/src/framebuffer.h
+++ b/src/framebuffer.h
@@ -15,18 +15,20 @@ typedef struct SRPFramebuffer
 SRPFramebuffer* srpNewFramebuffer(size_t width, size_t height);
 void srpFreeFramebuffer(SRPFramebuffer* this);
 
-void framebufferClear(SRPFramebuffer* this);
+void framebufferClear(const SRPFramebuffer* this);
 
 #ifdef SRP_SOURCE
 
+// The `const` qualifier is completely legal: only the buffer pointed to by
+// `framebuffer->color` is modified, not the structure itself!
 void framebufferDrawPixel(
-	SRPFramebuffer* this, size_t x, size_t y, double depth, uint32_t color
+	const SRPFramebuffer* this, size_t x, size_t y, double depth,
+	uint32_t color
 );
 
-void framebufferNDCToScreenSpace(SRPFramebuffer* this, double* NDC, double* SS);
-
-uint32_t* framebufferGetPixelPointer(SRPFramebuffer* this, size_t x, size_t y);
-double* framebufferGetDepthPointer(SRPFramebuffer* this, size_t x, size_t y);
+void framebufferNDCToScreenSpace(
+	const SRPFramebuffer* this, const double* NDC, double* SS
+);
 
 #endif  // ifdef SRP_SOURCE
 

--- a/src/mat.c
+++ b/src/mat.c
@@ -9,7 +9,7 @@ SRP_FORCEINLINE vec4d mat4dGetColumn(mat4d* a, uint8_t index)
 {
 	if (index >= 4)
 	{
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Attempt to OBB access mat4d (read): column index (%i)", index
 		);
@@ -28,7 +28,7 @@ SRP_FORCEINLINE void mat4dSetColumn(mat4d* a, vec4d column, uint8_t index)
 {
 	if (index >= 4)
 	{
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Attempt to OBB access mat4d (write): column index (%i)", index
 		);

--- a/src/mat.c
+++ b/src/mat.c
@@ -5,7 +5,7 @@
 #include "defines.h"
 #include "mat.h"
 
-SRP_FORCEINLINE vec4d mat4dGetColumn(mat4d* a, uint8_t index)
+SRP_FORCEINLINE vec4d mat4dGetColumn(const mat4d* a, uint8_t index)
 {
 	if (index >= 4)
 	{
@@ -41,7 +41,7 @@ SRP_FORCEINLINE void mat4dSetColumn(mat4d* a, vec4d column, uint8_t index)
 	a->data[3][index] = column.w;
 }
 
-SRP_FORCEINLINE vec4d mat4dMultiplyVec4d(mat4d* a, vec4d b)
+SRP_FORCEINLINE vec4d mat4dMultiplyVec4d(const mat4d* a, vec4d b)
 {
 	vec4d res = {0};
 	for (uint8_t i = 0; i < 4; i++)
@@ -54,7 +54,7 @@ SRP_FORCEINLINE vec4d mat4dMultiplyVec4d(mat4d* a, vec4d b)
 }
 
 
-SRP_FORCEINLINE mat4d mat4dMultiplyMat4d(mat4d* a, mat4d* b)
+SRP_FORCEINLINE mat4d mat4dMultiplyMat4d(const mat4d* a, mat4d* b)
 {
 	mat4d res = {0};
 	for (uint8_t i = 0; i < 4; i++)

--- a/src/mat.h
+++ b/src/mat.h
@@ -6,11 +6,11 @@
 typedef struct mat4 { float data[4][4]; } mat4;
 typedef struct mat4d { double data[4][4]; } mat4d;
 
-vec4d mat4dGetColumn(mat4d* a, uint8_t index);
+vec4d mat4dGetColumn(const mat4d* a, uint8_t index);
 void mat4dSetColumn(mat4d* a, vec4d column, uint8_t index);
 
-vec4d mat4dMultiplyVec4d(mat4d* a, vec4d b);
-mat4d mat4dMultiplyMat4d(mat4d* a, mat4d* b);
+vec4d mat4dMultiplyVec4d(const mat4d* a, vec4d b);
+mat4d mat4dMultiplyMat4d(const mat4d* a, mat4d* b);
 
 mat4d mat4dConstructIdentity();
 mat4d mat4dConstructScale(double x, double y, double z);

--- a/src/message_callback.c
+++ b/src/message_callback.c
@@ -7,7 +7,7 @@
 
 #define MAX_CHARS_IN_MESSAGE 1024
 
-void messageCallback(
+void srpMessageCallbackHelper(
 	SRPMessageType type, SRPMessageSeverity severity,
 	const char* sourceFunction, const char* format, ...
 )
@@ -17,7 +17,7 @@ void messageCallback(
 		char string[MAX_CHARS_IN_MESSAGE];
 		va_list variadic;
 		va_start(variadic, format);
-		snprintf(string, MAX_CHARS_IN_MESSAGE, format, variadic);
+		vsnprintf(string, MAX_CHARS_IN_MESSAGE, format, variadic);
 
 		srpContext.messageCallback(
 			type, severity, sourceFunction, string,

--- a/src/message_callback.h
+++ b/src/message_callback.h
@@ -20,7 +20,7 @@ typedef void (*SRPMessageCallbackType)(
 
 #ifdef SRP_SOURCE
 
-void messageCallback(
+void srpMessageCallbackHelper(
 	SRPMessageType type, SRPMessageSeverity severity,
 	const char* sourceFunction, const char* message, ...
 );

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -28,9 +28,9 @@ typedef struct
 	void (*shader)(
 		SRPvsInput* in, SRPvsOutput* out
 	);
-	size_t nBytesPerOutputVariables;
 	size_t nOutputVariables;
 	SRPVertexVariableInformation* outputVariables;
+	size_t nBytesPerOutputVariables;
 } SRPVertexShader;
 
 

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -15,12 +15,10 @@ typedef struct
 	size_t vertexID;
 } SRPvsInput;
 
-typedef struct VSOutputVariable VSOutputVariable;
-
 typedef struct
 {
 	double position[4];
-	VSOutputVariable* pOutputVariables;
+	SRPVertexVariable* pOutputVariables;
 } SRPvsOutput;
 
 // TODO: are nBytesPerOutputVariables and outputVariables[i].offsetBytes
@@ -32,7 +30,7 @@ typedef struct
 	);
 	size_t nBytesPerOutputVariables;
 	size_t nOutputVariables;
-	SRPVertexVariable* outputVariables;
+	SRPVertexVariableInformation* outputVariables;
 } SRPVertexShader;
 
 

--- a/src/texture.c
+++ b/src/texture.c
@@ -14,7 +14,7 @@
 
 #define N_CHANNELS_REQUESTED 3
 
-static vec4d textureGetColor(SRPTexture* this, size_t x, size_t y);
+static vec4d textureGetColor(const SRPTexture* this, size_t x, size_t y);
 
 SRPTexture* srpNewTexture(
 	const char* image,
@@ -56,7 +56,9 @@ void srpFreeTexture(SRPTexture* this)
 // through `out` argument
 // P.S: does not return `vec4d` because the user API should not enforce the use
 // of `vec` and `mat`
-void srpTextureGetFilteredColor(SRPTexture* this, double u, double v, double out[4])
+void srpTextureGetFilteredColor(
+	const SRPTexture* this, double u, double v, double out[4]
+)
 {
 	if (u < 0 || u > 1)
 	{
@@ -101,7 +103,7 @@ void srpTextureGetFilteredColor(SRPTexture* this, double u, double v, double out
 	}
 }
 
-static vec4d textureGetColor(SRPTexture* this, size_t x, size_t y)
+static vec4d textureGetColor(const SRPTexture* this, size_t x, size_t y)
 {
 	// Each pixel is N_CHANNELS_REQUESTED bytes, and an image is stored
 	// row-major

--- a/src/texture.c
+++ b/src/texture.c
@@ -27,7 +27,7 @@ SRPTexture* srpNewTexture(
 	this->data = stbi_load(image, &this->width, &this->height, NULL, N_CHANNELS_REQUESTED);
 	if (this->data == NULL)
 	{
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Failed to load image `%s`: %s", image, stbi_failure_reason()
 		);

--- a/src/texture.c
+++ b/src/texture.c
@@ -9,11 +9,12 @@
 #include "math_utils.h"
 #include "stb_image.h"
 #include "utils.h"
+#include "vec.h"
 #include "texture.h"
 
 #define N_CHANNELS_REQUESTED 3
 
-static SRPColor textureGetColor(SRPTexture* this, size_t x, size_t y);
+static vec4d textureGetColor(SRPTexture* this, size_t x, size_t y);
 
 SRPTexture* srpNewTexture(
 	const char* image,
@@ -45,12 +46,17 @@ void srpFreeTexture(SRPTexture* this)
 	SRP_FREE(this);
 }
 
-// TODO: now using only filteringModeMagnifying
-// how to know if texture is magnified or minified?
+// TODO: now using only filteringModeMagnifying; how to know if texture is 
+// magnified or minified?
 // TODO: too many conditionals?
-// TODO: return vec4 with values in [0, 1]? (this is what fragment shader
-// output assumes)
-SRPColor srpTextureGetFilteredColor(SRPTexture* this, double u, double v)
+// TODO: wrappingMode is untested!
+
+// Get a filtered color from texture and UV values
+// Returns an array of 4 double values each inside the interval [0, 1]
+// through `out` argument
+// P.S: does not return `vec4d` because the user API should not enforce the use
+// of `vec` and `mat`
+void srpTextureGetFilteredColor(SRPTexture* this, double u, double v, double out[4])
 {
 	if (u < 0 || u > 1)
 	{
@@ -77,25 +83,35 @@ SRPColor srpTextureGetFilteredColor(SRPTexture* this, double u, double v)
 		}
 	}
 
+	// V axis is pointed down-up, but images are stored up-down, so (1-v) here
 	double x = (this->width-1) * u;
 	double y = (this->height-1) * (1-v);
-	size_t x_min, y_min, x_max, y_max;
 
 	switch (this->filteringModeMagnifying)
 	{
 	case TF_NEAREST:
-		return textureGetColor(this, round(x), round(y));
+	{
+		vec4d ret = textureGetColor(this, round(x), round(y));
+		out[0] = ret.x;
+		out[1] = ret.y;
+		out[2] = ret.z;
+		out[3] = ret.w;
+		return;
+	}
 	}
 }
 
-static SRPColor textureGetColor(SRPTexture* this, size_t x, size_t y)
+static vec4d textureGetColor(SRPTexture* this, size_t x, size_t y)
 {
-	uint8_t* start = INDEX_VOID_PTR(this->data, x + y * this->width, N_CHANNELS_REQUESTED);
-	return (SRPColor) {
-		start[0],
-		start[1],
-		start[2],
-		(N_CHANNELS_REQUESTED == 3) ? 255 : start[3]
+	// Each pixel is N_CHANNELS_REQUESTED bytes, and an image is stored
+	// row-major
+	uint8_t* start = \
+		INDEX_VOID_PTR(this->data, x + y * this->width, N_CHANNELS_REQUESTED);
+	return (vec4d) {
+		start[0] / 255.,
+		start[1] / 255.,
+		start[2] / 255.,
+		(N_CHANNELS_REQUESTED == 3) ? 1. : (start[3] / 255.)
 	};
 }
 

--- a/src/texture.h
+++ b/src/texture.h
@@ -34,5 +34,7 @@ SRPTexture* srpNewTexture(
 );
 void srpFreeTexture(SRPTexture* this);
 
-void srpTextureGetFilteredColor(SRPTexture* this, double u, double v, double out[4]);
+void srpTextureGetFilteredColor(
+	const SRPTexture* this, double u, double v, double out[4]
+);
 

--- a/src/texture.h
+++ b/src/texture.h
@@ -34,5 +34,5 @@ SRPTexture* srpNewTexture(
 );
 void srpFreeTexture(SRPTexture* this);
 
-SRPColor srpTextureGetFilteredColor(SRPTexture* this, double u, double v);
+void srpTextureGetFilteredColor(SRPTexture* this, double u, double v, double out[4]);
 

--- a/src/triangle.c
+++ b/src/triangle.c
@@ -221,6 +221,7 @@ static void triangleInterpolatePositionAndVertexVariables(
 	}
 
 	// interpolate variables (attributes)
+	size_t attrOffsetBytes = 0;
 	for (size_t attrI = 0; attrI < sp->vs.nOutputVariables; attrI++)
 	{
 		SRPVertexVariableInformation* attr = &sp->vs.outputVariables[attrI];
@@ -234,11 +235,11 @@ static void triangleInterpolatePositionAndVertexVariables(
 
 			// pointers to the current attribute of 0th, 1st and 2nd vertices
 			double* AV0 = (double*) \
-				ADD_VOID_PTR(vertices[0].pOutputVariables, attr->offsetBytes);
+				ADD_VOID_PTR(vertices[0].pOutputVariables, attrOffsetBytes);
 			double* AV1 = (double*) \
-				ADD_VOID_PTR(vertices[1].pOutputVariables, attr->offsetBytes);
+				ADD_VOID_PTR(vertices[1].pOutputVariables, attrOffsetBytes);
 			double* AV2 = (double*) \
-				ADD_VOID_PTR(vertices[2].pOutputVariables, attr->offsetBytes);
+				ADD_VOID_PTR(vertices[2].pOutputVariables, attrOffsetBytes);
 
 			for (size_t elemI = 0; elemI < attr->nItems; elemI++)
 			{
@@ -257,6 +258,7 @@ static void triangleInterpolatePositionAndVertexVariables(
 		}
 		size_t attrSize = elemSize * attr->nItems;
 		pInterpolatedAttrVoid = (uint8_t*) pInterpolatedAttrVoid + attrSize;
+		attrOffsetBytes += attrSize;
 	}
 }
 

--- a/src/triangle.c
+++ b/src/triangle.c
@@ -17,7 +17,7 @@ static double signedAreaParallelogram(
 );
 static void calculateBarycentricCoordinatesForPointAndBarycentricDeltas(
 	const vec3d* restrict SSPositions, const vec3d* restrict edgeVectors,
-	const vec2d point, double* restrict barycentricCoordinates,
+	vec2d point, double* restrict barycentricCoordinates,
 	double* restrict barycentricDeltaX, double* restrict barycentricDeltaY
 );
 static bool triangleIsEdgeFlatTopOrLeft(const vec3d* restrict edgeVector);
@@ -29,7 +29,7 @@ static void triangleInterpolatePositionAndVertexVariables(
 );
 
 void drawTriangle(
-	SRPFramebuffer* fb, const SRPvsOutput vertices[3],
+	const SRPFramebuffer* fb, const SRPvsOutput vertices[3],
 	const SRPShaderProgram* restrict sp, size_t primitiveID
 )
 {

--- a/src/triangle.c
+++ b/src/triangle.c
@@ -250,7 +250,7 @@ static void triangleInterpolatePositionAndVertexVariables(
 			break;
 		}
 		default:
-			messageCallback(
+			srpMessageCallbackHelper(
 				MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 				"Unexpected type (%i)", attr->type
 			);

--- a/src/triangle.c
+++ b/src/triangle.c
@@ -223,7 +223,7 @@ static void triangleInterpolatePositionAndVertexVariables(
 	// interpolate variables (attributes)
 	for (size_t attrI = 0; attrI < sp->vs.nOutputVariables; attrI++)
 	{
-		SRPVertexVariable* attr = &sp->vs.outputVariables[attrI];
+		SRPVertexVariableInformation* attr = &sp->vs.outputVariables[attrI];
 		size_t elemSize = 0;
 		switch (attr->type)
 		{

--- a/src/triangle.h
+++ b/src/triangle.h
@@ -7,7 +7,7 @@
 #include "vec.h"
 
 void drawTriangle(
-	SRPFramebuffer* fb, const SRPvsOutput vertices[3],
+	const SRPFramebuffer* fb, const SRPvsOutput vertices[3],
 	const SRPShaderProgram* restrict sp, size_t primitiveID
 );
 

--- a/src/type.c
+++ b/src/type.c
@@ -22,7 +22,7 @@ size_t SIZEOF_TYPE(Type type)
 			return sizeof(double);
 		default:
 		{
-			messageCallback(
+			srpMessageCallbackHelper(
 				MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 				"Unknown type (%i)", type
 			);

--- a/src/vec.c
+++ b/src/vec.c
@@ -38,7 +38,7 @@ SRP_FORCEINLINE double vec4dIndex(vec4d a, uint8_t index)
 {
 	if (index >= 4)
 	{
-		messageCallback(
+		srpMessageCallbackHelper(
 			MESSAGE_ERROR, MESSAGE_SEVERITY_HIGH, __func__,
 			"Attempt to OBB access vec4d: index (%i)", index
 		);

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -4,11 +4,12 @@
 #include "type.h"
 
 typedef struct SRPVertex SRPVertex;
+typedef struct SRPVertexVariable SRPVertexVariable;
 
 typedef struct
 {
 	size_t nItems;
 	Type type;
 	size_t offsetBytes;
-} SRPVertexVariable;
+} SRPVertexVariableInformation;
 

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -10,6 +10,5 @@ typedef struct
 {
 	size_t nItems;
 	Type type;
-	size_t offsetBytes;
 } SRPVertexVariableInformation;
 


### PR DESCRIPTION
- Make `srpTextureGetFilteredColor` return an array of [0, 1] values (just as fragment shader's output assumes)
- Fix message callback not working
- Rename:
    - `SRPVertexVariable` -> `SRPVertexVariableInformation`
    - `VSOutputVariable` -> `SRPVertexVariable`
- Add `srpDrawVertexBuffer`
- Add `const` to function declarations where it is possible
- Remove `SRPVertexVariableInformation.offsetBytes` due to uselessness
- Reorder arguments in drawcalls (`srpDraw...`)